### PR TITLE
Add restore step for test project in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,9 @@ jobs:
     - name: Build
       run: dotnet build src/Univertall/Univertall.csproj --configuration Release --no-restore
 
+    - name: Restore test project dependencies
+      run: dotnet restore tests/Univertall.Tests/Univertall.Tests.csproj
+
     - name: Test
       run: dotnet test --no-restore --verbosity normal
 


### PR DESCRIPTION
Added a new step in `release.yml` to restore dependencies for the test project before the build and test steps. This ensures that the test project's dependencies are properly restored, maintaining the integrity and consistency of the build process.